### PR TITLE
feat: document transfer account

### DIFF
--- a/src/contract.js
+++ b/src/contract.js
@@ -67,7 +67,6 @@ export const start = async (zcf, privateArgs) => {
       const celestia = await orch.getChain('celestia');
       const agoric = await orch.getChain('agoric');
 
-      /** @typedef {import('./index').ChainAccount[]} */
       const [celestiaAccount, localAccount] = await Promise.all([
         celestia.makeAccount('main'),
         agoric.makeAccount('main'),
@@ -92,7 +91,7 @@ export const start = async (zcf, privateArgs) => {
       });
 
       await localAccount
-        .transfer(transferMsg)
+        .transferSteps(give.USDC, transferMsg)
         .then((_txResult) =>
           celestiaAccount.delegate(offerArgs.validator, offerArgs.staked),
         )

--- a/src/contract.js
+++ b/src/contract.js
@@ -39,13 +39,13 @@ export const start = async (zcf, privateArgs) => {
 
       // We would actually alreaady have the account from the orchestrator
       const celestia = await orch.getChain('celestia');
-      const celestiaAccount = await celestia.makeAccount('main');
+      const celestiaAccount = await celestia.makeAccount();
 
       const delegations = await celestiaAccount.getDelegations();
       await celestiaAccount.undelegateAll(delegations);
 
       const stride = await orch.getChain('stride');
-      const strideAccount = await stride.makeAccount('LST');
+      const strideAccount = await stride.makeAccount();
 
       // TODO the `TIA` string actaully needs to be the Brand from AgoricNames
       const tiaAmt = await celestiaAccount.getBalance('TIA');
@@ -68,8 +68,8 @@ export const start = async (zcf, privateArgs) => {
       const agoric = await orch.getChain('agoric');
 
       const [celestiaAccount, localAccount] = await Promise.all([
-        celestia.makeAccount('main'),
-        agoric.makeAccount('main'),
+        celestia.makeAccount(),
+        agoric.makeAccount(),
       ]);
 
       const tiaAddress = await celestiaAccount.getAddress();

--- a/src/orchestration.d.ts
+++ b/src/orchestration.d.ts
@@ -229,6 +229,19 @@ export interface ChainAccount {
 }
 
 /**
+ * A LocalChain account that has the ability to intercept IBC Transfer
+ * packets and react to them. a.k.a. "IBC Hooks"
+ */
+
+export interface TransferAccount extends ChainAccount {
+  /**
+   * Register a hook to intercept an incoming IBC Transfer.
+   * Calling without arguments will unregister the hook
+   */
+  interceptTransfer: (tap?: { upcall: (args: any) => Promise<any> }) => void;
+}
+
+/**
  * An object that supports high-level operations for an account on a remote chain.
  */
 export interface OrchestrationAccount {

--- a/src/orchestration.d.ts
+++ b/src/orchestration.d.ts
@@ -194,10 +194,9 @@ export interface Chain<C extends keyof KnownChains> {
 
   /**
    * Make a new account on the remote chain.
-   * @param name - account name for logging and tracing purposes
    * @returns an object that controls a new remote account on Chain
    */
-  makeAccount: (name?: string) => Promise<OrchestrationAccount<C>>;
+  makeAccount: () => Promise<OrchestrationAccount<C>>;
   // FUTURE supply optional port object; also fetch port object
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,5 @@
-import '@agoric/zoe/exported.js';
-import type { ChainAddress } from './orchestration';
-
-// TODO figure out ERTP requirements
-type Brand = unknown;
-type Amount<T extends 'nat' = 'nat'> = { brand: Brand; value: bigint };
+import type { Amount, Brand } from '@agoric/ertp/exported.js';
+import type { TransferMsg, ChainAddress } from './orchestration';
 
 type AfterAction = { destChain: string; destAddress: ChainAddress };
 type SwapExact = { amountIn: Amount; amountOut: Amount };
@@ -14,22 +10,20 @@ export type OsmosisSwapArgs = (SwapExact | SwapMaxSlippage) &
 export const orcUtils = {
   /**
    * unwinds denom with PFM, if necessary
-   *
-   * @param {Omit<import('./index').TransferMsg, 'memo'>} _args
-   * @returns {import('./index').TransferMsg}
    */
-  makeTransferMsg: (_args) => {
-    // XXX unwind denoms
-    return {};
+  makeTransferMsg: (_args: Omit<TransferMsg, 'memo'>) => {
+    // XXX mocked, so typescript is happy
+    return {
+      toAccount: { chainId: 'osmosis-test', address: 'osmo1234' },
+    } as TransferMsg;
   },
   /**
    * SwapExact or SwapMaxSlippage, with optional AfterAction
-   * @param {import('./index').OsmosisSwapArgs} _args
-   * @returns {import('./index').TransferMsg}
    */
-  makeOsmosisSwap(_args) {
-    // XXX unwind denoms
-    // XXX swap msg
-    return {};
+  makeOsmosisSwap(_args: OsmosisSwapArgs) {
+    // XXX mocked, so typescript is happy
+    return {
+      toAccount: { chainId: 'osmosis-test', address: 'osmo1234' },
+    } as TransferMsg;
   },
 };


### PR DESCRIPTION
- Documents ability to register a transfer interceptor (ibc hook) from a LocalChain (agoric) Account
- Add `methods` key to entries in `KnownChains` so we can specify things like `.liquidStake` and `.interceptTransfer` 
- Add generic type parameter to `Chain` interface for type-safe access to chain-specific methods and info


<img width="609" alt="image" src="https://github.com/agoric-labs/orchestration-api-spec/assets/11021913/1ef0a4b7-bb58-4430-931f-97a4438a1c83">
<img width="629" alt="image" src="https://github.com/agoric-labs/orchestration-api-spec/assets/11021913/93fe8301-3333-41cf-8e47-47d33140b236">

